### PR TITLE
Documentation fix of the default value of samba_map_to_guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ No specific requirements
 | `samba_log`                    | -                        | Set the log file. If left undefined, logging is done through syslog.                                                         |
 | `samba_log_size`               | 5000                     | Set the maximum size of the log file.                                                                                        |
 | `samba_log_level`              | 0                        | Set Samba log level, 0 is least verbose and 10 is a flood of debug output.                                                   |
-| `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                                                                         |
+| `samba_map_to_guest`           | `never`                  | Behaviour when unregistered users access the shares.                                                                         |
 | `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                                     |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                             |
 | `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                                   |


### PR DESCRIPTION
Default value of the `samba_map_to_guest` is `never`, not `bad user`: https://github.com/bertvv/ansible-role-samba/blob/812643507e2cc5e119d8de5338762d8b4eecf156/defaults/main.yml#L11